### PR TITLE
Fix "usage" bug

### DIFF
--- a/scripts/kraken2-inspect
+++ b/scripts/kraken2-inspect
@@ -42,7 +42,7 @@ GetOptions(
   "report-zero-counts" => \$report_zero_counts,
 );
 
-if (@ARGV) {
+if (@ARGV < 1) {
   usage();
 }
 eval { $db_prefix = kraken2lib::find_db($db_prefix); };


### PR DESCRIPTION
I found a bug where if the script is used correctly, it will exit with the usage statement.