### PR TITLE
Prefix auxiliary executables with kraken2_

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.o
-src/build_db
-src/classify
-src/estimate_capacity
-src/dump_table
-src/lookup_accession_numbers
+src/kraken2_build_db
+src/kraken2_classify
+src/kraken2_estimate_capacity
+src/kraken2_dump_table
+src/kraken2_lookup_accession_numbers

--- a/install_kraken2.sh
+++ b/install_kraken2.sh
@@ -44,7 +44,7 @@ echo "Kraken 2 installation complete."
 echo
 echo "To make things easier for you, you may want to copy/symlink the following"
 echo "files into a directory in your PATH:"
-for file in $KRAKEN2_DIR/kraken2*
+for file in $KRAKEN2_DIR/kraken2 $KRAKEN2_DIR/kraken2-*
 do
   if [ -x "$file" ]
   then

--- a/scripts/build_kraken2_db.sh
+++ b/scripts/build_kraken2_db.sh
@@ -81,7 +81,7 @@ else
   grep "^TAXID" taxonomy/prelim_map.txt | cut -f 2- > $seqid2taxid_map_file.tmp || true
   if grep "^ACCNUM" taxonomy/prelim_map.txt | cut -f 2- > accmap_file.tmp; then
     if compgen -G "taxonomy/*.accession2taxid" > /dev/null; then
-      lookup_accession_numbers accmap_file.tmp taxonomy/*.accession2taxid > seqid2taxid_acc.tmp
+      kraken2_lookup_accession_numbers accmap_file.tmp taxonomy/*.accession2taxid > seqid2taxid_acc.tmp
       cat seqid2taxid_acc.tmp >> $seqid2taxid_map_file.tmp
       rm seqid2taxid_acc.tmp
     else
@@ -98,7 +98,7 @@ fi
 echo "Estimating required capacity (step 2)..."
 
 step_time=$(get_current_time)
-estimate=$(list_sequence_files | xargs -0 cat | estimate_capacity -k $KRAKEN2_KMER_LEN -l $KRAKEN2_MINIMIZER_LEN -S $KRAKEN2_SEED_TEMPLATE -p $KRAKEN2_THREAD_CT $KRAKEN2XFLAG )
+estimate=$(list_sequence_files | xargs -0 cat | kraken2_estimate_capacity -k $KRAKEN2_KMER_LEN -l $KRAKEN2_MINIMIZER_LEN -S $KRAKEN2_SEED_TEMPLATE -p $KRAKEN2_THREAD_CT $KRAKEN2XFLAG )
 required_capacity=$(perl -le 'print int(shift() / 0.7)' $estimate);
 
 echo "Estimated hash table requirement: $(( required_capacity * 4 )) bytes"
@@ -123,7 +123,7 @@ then
 else
   step_time=$(get_current_time)
   list_sequence_files | xargs -0 cat | \
-    build_db -k $KRAKEN2_KMER_LEN -l $KRAKEN2_MINIMIZER_LEN -S $KRAKEN2_SEED_TEMPLATE $KRAKEN2XFLAG \
+    kraken2_build_db -k $KRAKEN2_KMER_LEN -l $KRAKEN2_MINIMIZER_LEN -S $KRAKEN2_SEED_TEMPLATE $KRAKEN2XFLAG \
              -H hash.k2d.tmp -t taxo.k2d.tmp -o opts.k2d.tmp -n taxonomy/ -m $seqid2taxid_map_file \
              -c $required_capacity -p $KRAKEN2_THREAD_CT $max_db_flag
   finalize_file taxo.k2d

--- a/scripts/kraken2
+++ b/scripts/kraken2
@@ -16,7 +16,7 @@ my $PROG = basename $0;
 my $KRAKEN2_DIR = "#####=KRAKEN2_DIR=#####";
 
 # Test to see if the executables got moved, try to recover if we can
-if (! -e "$KRAKEN2_DIR/classify") {
+if (! -e "$KRAKEN2_DIR/kraken2_classify") {
   use Cwd 'abs_path';
   $KRAKEN2_DIR = dirname abs_path($0);
 }
@@ -25,7 +25,7 @@ require "$KRAKEN2_DIR/kraken2lib.pm";
 $ENV{"KRAKEN2_DIR"} = $KRAKEN2_DIR;
 $ENV{"PATH"} = "$KRAKEN2_DIR:$ENV{PATH}";
 
-my $CLASSIFY = "$KRAKEN2_DIR/classify";
+my $CLASSIFY = "$KRAKEN2_DIR/kraken2_classify";
 my $GZIP_MAGIC = chr(hex "1f") . chr(hex "8b");
 my $BZIP2_MAGIC = "BZ";
 

--- a/scripts/kraken2-build
+++ b/scripts/kraken2-build
@@ -15,7 +15,7 @@ my $PROG = basename $0;
 my $KRAKEN2_DIR = "#####=KRAKEN2_DIR=#####";
 
 # Test to see if the executables got moved, try to recover if we can
-if (! -e "$KRAKEN2_DIR/classify") {
+if (! -e "$KRAKEN2_DIR/kraken2_classify") {
   use Cwd 'abs_path';
   $KRAKEN2_DIR = dirname abs_path($0);
 }

--- a/scripts/kraken2-inspect
+++ b/scripts/kraken2-inspect
@@ -25,7 +25,7 @@ require "$KRAKEN2_DIR/kraken2lib.pm";
 $ENV{"KRAKEN2_DIR"} = $KRAKEN2_DIR;
 $ENV{"PATH"} = "$KRAKEN2_DIR:$ENV{PATH}";
 
-my $DUMP_TABLE = "$KRAKEN2_DIR/dump_table";
+my $DUMP_TABLE = "$KRAKEN2_DIR/kraken2_dump_table";
 
 my $db_prefix;
 my $names_in_output = 0;

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,7 +4,7 @@ CXXFLAGS += -DLINEAR_PROBING
 
 .PHONY: all clean install
 
-PROGS = estimate_capacity build_db classify dump_table lookup_accession_numbers
+PROGS = kraken2_estimate_capacity kraken2_build_db kraken2_classify kraken2_dump_table kraken2_lookup_accession_numbers
 
 all: $(PROGS)
 
@@ -24,12 +24,17 @@ reports.o: reports.cc reports.h
 aa_translate.o: aa_translate.cc aa_translate.h
 utilities.o: utilities.cc utilities.h
 
-build_db: build_db.cc mmap_file.o compact_hash.o taxonomy.o seqreader.o mmscanner.o omp_hack.o utilities.o
+kraken2_build_db: build_db.cc mmap_file.o compact_hash.o taxonomy.o seqreader.o mmscanner.o omp_hack.o utilities.o
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $^ -o $@
 
-classify: classify.cc reports.o mmap_file.o compact_hash.o taxonomy.o seqreader.o mmscanner.o omp_hack.o aa_translate.o utilities.o
+kraken2_classify: classify.cc reports.o mmap_file.o compact_hash.o taxonomy.o seqreader.o mmscanner.o omp_hack.o aa_translate.o utilities.o
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $^ -o $@
 
-estimate_capacity: estimate_capacity.cc seqreader.o mmscanner.o omp_hack.o utilities.o
+kraken2_estimate_capacity: estimate_capacity.cc seqreader.o mmscanner.o omp_hack.o utilities.o
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $^ -o $@
 
-dump_table: dump_table.cc mmap_file.o compact_hash.o omp_hack.o taxonomy.o reports.o
+kraken2_dump_table: dump_table.cc mmap_file.o compact_hash.o omp_hack.o taxonomy.o reports.o
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $^ -o $@
 
-lookup_accession_numbers: lookup_accession_numbers.cc mmap_file.o omp_hack.o utilities.o
+kraken2_lookup_accession_numbers: lookup_accession_numbers.cc mmap_file.o omp_hack.o utilities.o
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $^ -o $@

--- a/src/build_db.cc
+++ b/src/build_db.cc
@@ -311,7 +311,7 @@ void ParseCommandLine(int argc, char **argv, Options &opts) {
 }
 
 void usage(int exit_code) {
-  cerr << "Usage: build_db <options>\n"
+  cerr << "Usage: kraken2_build_db <options>\n"
        << "\n"
        << "Options (*mandatory):\n"
        << "* -H FILENAME   Kraken 2 hash table filename\n"

--- a/src/estimate_capacity.cc
+++ b/src/estimate_capacity.cc
@@ -154,7 +154,7 @@ void ParseCommandLine(int argc, char **argv, Options &opts) {
 }
 
 void usage(int exit_code) {
-  cerr << "Usage: estimate_capacity <options>" << endl
+  cerr << "Usage: kraken2_estimate_capacity <options>" << endl
        << endl
        << "Options (*mandatory):" << endl
        << "* -k INT        Set length of k-mers" << endl

--- a/src/lookup_accession_numbers.cc
+++ b/src/lookup_accession_numbers.cc
@@ -15,7 +15,7 @@ using std::vector;
 
 int main(int argc, char **argv) {
   if (argc < 3)
-    errx(EX_USAGE, "Usage: lookup_accession_numbers <lookup file> <accmaps>");
+    errx(EX_USAGE, "Usage: kraken2_lookup_accession_numbers <lookup file> <accmaps>");
 
   unordered_map<string, vector<string>> target_lists;
   std::ifstream lookup_list_file(argv[1]);


### PR DESCRIPTION
This allows kraken2 to be installed to the same prefix as kraken/krakenuniq without any name
conflicts of the auxiliary executables.