### PR TITLE
Add CMakeLists.txt files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(kraken2)
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_compile_options(-Wall)
+add_definitions(-DLINEAR_PROBING)
+
+set(CMAKE_CXX_FLAGS_DEBUG "-g")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3")
+
+include(FindOpenMP)
+if(OPENMP_FOUND)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
+else(OPENMP_FOUND)
+    message("ERROR: OpenMP could not be found.")
+endif(OPENMP_FOUND)
+
+add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,42 @@
+add_executable(build_db
+        build_db.cc
+        mmap_file.cc
+        compact_hash.cc
+        taxonomy.cc
+        seqreader.cc
+        mmscanner.cc
+        omp_hack.cc
+        utilities.cc)
+
+add_executable(classify
+        classify.cc
+        reports.cc
+        mmap_file.cc
+        compact_hash.cc
+        taxonomy.cc
+        seqreader.cc
+        mmscanner.cc
+        omp_hack.cc
+        aa_translate.cc
+        utilities.cc)
+
+add_executable(estimate_capacity
+        estimate_capacity.cc
+        seqreader.cc
+        mmscanner.cc
+        omp_hack.cc
+        utilities.cc)
+
+add_executable(dump_table
+        dump_table.cc
+        mmap_file.cc
+        compact_hash.cc
+        omp_hack.cc
+        taxonomy.cc
+        reports.cc)
+
+add_executable(lookup_accession_numbers
+        lookup_accession_numbers.cc
+        mmap_file.cc
+        omp_hack.cc
+        utilities.cc)


### PR DESCRIPTION
The addition of these two `CMakeLists.txt` files allows K2 to be built using `cmake`.  This has the benefit (for me at least) of making it easy to develop with [CLion](https://www.jetbrains.com/clion/), which uses cmake internally.  It also makes it easier to code with other system besides CLion via `cmake`'s "generators."  I have tested these on my Mac with `clang++` 10.0.0 and CLion 2020.1.