### PR TITLE
Fix guard around `omp_destroy_lock` calls

### DIFF
--- a/src/compact_hash.cc
+++ b/src/compact_hash.cc
@@ -42,8 +42,10 @@ CompactHashTable::CompactHashTable(size_t capacity,
 CompactHashTable::~CompactHashTable() {
   if (! file_backed_) {
     delete[] table_;
-    for (size_t i = 0; i < LOCK_ZONES; i++)
-      omp_destroy_lock(&zone_locks_[i]);
+    if (! from_file_) {
+      for (size_t i = 0; i < LOCK_ZONES; i++)
+        omp_destroy_lock(&zone_locks_[i]);
+    }
   }
 }
 
@@ -56,6 +58,7 @@ CompactHashTable::CompactHashTable(const char *filename, bool memory_mapping) {
 }
 
 void CompactHashTable::LoadTable(const char *filename, bool memory_mapping) {
+  from_file_ = true;
   if (memory_mapping) {
     backing_file_.OpenFile(filename);
     char *ptr = backing_file_.fptr();

--- a/src/compact_hash.h
+++ b/src/compact_hash.h
@@ -100,6 +100,7 @@ class CompactHashTable : public KeyValueStore {
   bool file_backed_;
   MMapFile backing_file_;
   omp_lock_t zone_locks_[LOCK_ZONES];
+  bool from_file_ = false;
 
   CompactHashTable(const CompactHashTable &rhs);
   CompactHashTable& operator=(const CompactHashTable &rhs);


### PR DESCRIPTION
The current `if (! file_backed_)` guard around the calls to `omp_destroy_lock` isn't quite right.  If loading db from a file but not using memory mapping, `file_backed_ ` is `false`, but the `omp_init_lock` calls haven't happened.  That gave me illegal access errors in my tests.  This fixes it by introducing a new boolean field that is true only when the db is loaded from a file (regardless of memory mapping) and guarding the `omp_destroy_lock` calls with that instead.