### PR TITLE
Fix for failing build with GCC-10

### DIFF
--- a/src/hyperloglogplus.h
+++ b/src/hyperloglogplus.h
@@ -13,6 +13,7 @@
 #ifndef HYPERLOGLOGPLUS_H_
 #define HYPERLOGLOGPLUS_H_
 
+#include "kraken2_headers.h"
 #include<vector>
 #include<unordered_set>
 using namespace std;


### PR DESCRIPTION
Currently the build seems to not work with GCC-10 with the following error:

```
...
g++ -g -O2 -fdebug-prefix-map=/build/kraken2-2.1.0=. -fstack-protector-strong -Wformat -Werror=format-security -fopenmp -Wall -std=c++11 -O3 -DLINEAR_PROBING -Wdate-time -                  D_FORTIFY_SOURCE=2  -c -o aa_translate.o aa_translate.cc
In file included from hyperloglogplus.cc:8:
hyperloglogplus.h:30:1: error: 'uint64_t' does not name a type
   30 | uint64_t murmurhash3_finalizer (uint64_t key);
      | ^~~~~~~~
hyperloglogplus.h:35:23: error: 'uint32_t' was not declared in this scope
   35 | typedef unordered_set<uint32_t> SparseListType;
      |                       ^~~~~~~~
hyperloglogplus.h:35:31: error: template argument 1 is invalid
   35 | typedef unordered_set<uint32_t> SparseListType;
      |                               ^
hyperloglogplus.h:35:31: error: template argument 2 is invalid
hyperloglogplus.h:35:31: error: template argument 3 is invalid
hyperloglogplus.h:35:31: error: template argument 4 is invalid
hyperloglogplus.h:52:3: error: 'uint8_t' does not name a type
```

This is an attempt to fix the same