### PR TITLE
Add required sources to cmake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,8 @@ add_executable(classify
         mmscanner.cc
         omp_hack.cc
         aa_translate.cc
-        utilities.cc)
+        utilities.cc
+        hyperloglogplus.cc)
 
 add_executable(estimate_capacity
         estimate_capacity.cc
@@ -33,7 +34,8 @@ add_executable(dump_table
         compact_hash.cc
         omp_hack.cc
         taxonomy.cc
-        reports.cc)
+        reports.cc
+        hyperloglogplus.cc)
 
 add_executable(lookup_accession_numbers
         lookup_accession_numbers.cc


### PR DESCRIPTION
hyperloglogplus.cc was missing for some executables with cmake

> [ 76%] Linking CXX executable classify
> CMakeFiles/classify.dir/classify.cc.o: In function `ClassifySequence(kraken2::Sequence&, kraken2::Sequence&, std::__cxx11::basic_ostringstream<char, std::char_traits<char>, std::allocator<char> >&, kraken2::KeyValueStore*, kraken2::Taxonomy&, kraken2::IndexOptions&, Options&, ClassificationStats&, kraken2::MinimizerScanner&, std::vector<unsigned long, std::allocator<unsigned long> >&, std::unordered_map<unsigned long, unsigned long, std::hash<unsigned long>, std::equal_to<unsigned long>, std::allocator<std::pair<unsigned long const, unsigned long> > >&, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&, std::unordered_map<unsigned long, kraken2::ReadCounts<HyperLogLogPlusMinus<unsigned long> >, std::hash<unsigned long>, std::equal_to<unsigned long>, std::allocator<std::pair<unsigned long const, kraken2::ReadCounts<HyperLogLogPlusMinus<unsigned long> > > > >&)':
> classify.cc:(.text+0x420c): undefined reference to `HyperLogLogPlusMinus<unsigned long>::insert(unsigned long)'
> CMakeFiles/classify.dir/classify.cc.o: In function `ProcessFiles(char const*, char const*, kraken2::KeyValueStore*, kraken2::Taxonomy&, kraken2::IndexOptions&, Options&, ClassificationStats&, OutputStreamData&, std::unordered_map<unsigned long, kraken2::ReadCounts<HyperLogLogPlusMinus<unsigned long> >, std::hash<unsigned long>, std::equal_to<unsigned long>, std::allocator<std::pair<unsigned long const, kraken2::ReadCounts<HyperLogLogPlusMinus<unsigned long> > > > >&) [clone ._omp_fn.0]':
> classify.cc:(.text+0x6b16): undefined reference to `HyperLogLogPlusMinus<unsigned long>::operator+=(HyperLogLogPlusMinus<unsigned long>&&)'
> CMakeFiles/classify.dir/classify.cc.o: In function `std::__detail::_Map_base<unsigned long, std::pair<unsigned long const, kraken2::ReadCounts<HyperLogLogPlusMinus<unsigned long> > >, std::allocator<std::pair<unsigned long const, kraken2::ReadCounts<HyperLogLogPlusMinus<unsigned long> > > >, std::__detail::_Select1st, std::equal_to<unsigned long>, std::hash<unsigned long>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true>, true>::operator[](unsigned long const&)':
> classify.cc:(.text._ZNSt8__detail9_Map_baseImSt4pairIKmN7kraken210ReadCountsI20HyperLogLogPlusMinusImEEEESaIS8_ENS_10_Select1stESt8equal_toImESt4hashImENS_18_Mod_range_hashingENS_20_Default_ranged_hashENS_20_Prime_rehash_policyENS_17_Hashtable_traitsILb0ELb0ELb1EEELb1EEixERS2_[_ZNSt8__detail9_Map_baseImSt4pairIKmN7kraken210ReadCountsI20HyperLogLogPlusMinusImEEEESaIS8_ENS_10_Select1stESt8equal_toImESt4hashImENS_18_Mod_range_hashingENS_20_Default_ranged_hashENS_20_Prime_rehash_policyENS_17_Hashtable_traitsILb0ELb0ELb1EEELb1EEixERS2_]+0x6c): undefined reference to `murmurhash3_finalizer(unsigned long)'
> classify.cc:(.text._ZNSt8__detail9_Map_baseImSt4pairIKmN7kraken210ReadCountsI20HyperLogLogPlusMinusImEEEESaIS8_ENS_10_Select1stESt8equal_toImESt4hashImENS_18_Mod_range_hashingENS_20_Default_ranged_hashENS_20_Prime_rehash_policyENS_17_Hashtable_traitsILb0ELb0ELb1EEELb1EEixERS2_[_ZNSt8__detail9_Map_baseImSt4pairIKmN7kraken210ReadCountsI20HyperLogLogPlusMinusImEEEESaIS8_ENS_10_Select1stESt8equal_toImESt4hashImENS_18_Mod_range_hashingENS_20_Default_ranged_hashENS_20_Prime_rehash_policyENS_17_Hashtable_traitsILb0ELb0ELb1EEELb1EEixERS2_]+0xa0): undefined reference to `HyperLogLogPlusMinus<unsigned long>::HyperLogLogPlusMinus(unsigned char, bool, unsigned long (*)(unsigned long))'
> CMakeFiles/classify.dir/reports.cc.o: In function `kraken2::PrintKrakenStyleReportLine(std::basic_ofstream<char, std::char_traits<char> >&, bool, unsigned long, kraken2::ReadCounts<HyperLogLogPlusMinus<unsigned long> >, kraken2::ReadCounts<HyperLogLogPlusMinus<unsigned long> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int)':
> reports.cc:(.text+0x306): undefined reference to `HyperLogLogPlusMinus<unsigned long>::size() const'
> CMakeFiles/classify.dir/reports.cc.o: In function `kraken2::GetCladeCounters(kraken2::Taxonomy&, std::unordered_map<unsigned long, kraken2::ReadCounts<HyperLogLogPlusMinus<unsigned long> >, std::hash<unsigned long>, std::equal_to<unsigned long>, std::allocator<std::pair<unsigned long const, kraken2::ReadCounts<HyperLogLogPlusMinus<unsigned long> > > > >&)':
> 