### PR TITLE
Update build_kraken2_db.sh

### DIFF
--- a/scripts/build_kraken2_db.sh
+++ b/scripts/build_kraken2_db.sh
@@ -32,7 +32,7 @@ function report_time_elapsed() {
 }
 
 function list_sequence_files() {
-  find library/ '(' -name '*.fna' -o -name '*.faa' ')' -print0
+  find -L library/ '(' -name '*.fna' -o -name '*.faa' ')' -print0
 }
 
 start_time=$(get_current_time)


### PR DESCRIPTION
Addressing #568 that kraken2-build doesn't follow symlinked subdirectories when searching for input fna or faa files. Added -L option to the find command in list_sequence_files(). This allows it to traverse symlinks in the library directory.  It is particularly useful when building multiple databases with shared reference sequences, as symlinking may be preferable to save space.