### PR TITLE
Updated kraken2-build to allow symlinks in the library directory

### DIFF
--- a/scripts/build_kraken2_db.sh
+++ b/scripts/build_kraken2_db.sh
@@ -32,7 +32,7 @@ function report_time_elapsed() {
 }
 
 function list_sequence_files() {
-  find library/ '(' -name '*.fna' -o -name '*.faa' ')' -print0
+  find -L library/ '(' -name '*.fna' -o -name '*.faa' ')' -print0
 }
 
 start_time=$(get_current_time)

--- a/scripts/build_kraken2_db.sh
+++ b/scripts/build_kraken2_db.sh
@@ -66,14 +66,14 @@ fi
 
 echo "Creating sequence ID to taxonomy ID map (step 1)..."
 if [ -d "library/added" ]; then
-  find library/added/ -name 'prelim_map_*.txt' | xargs cat > library/added/prelim_map.txt
+  find -L library/added/ -name 'prelim_map_*.txt' | xargs cat > library/added/prelim_map.txt
 fi
 seqid2taxid_map_file=seqid2taxid.map
 if [ -e "$seqid2taxid_map_file" ]; then
   echo "Sequence ID to taxonomy ID map already present, skipping map creation."
 else
   step_time=$(get_current_time)
-  find library/ -maxdepth 2 -name prelim_map.txt | xargs cat > taxonomy/prelim_map.txt
+  find -L library/ -maxdepth 2 -name prelim_map.txt | xargs cat > taxonomy/prelim_map.txt
   if [ ! -s "taxonomy/prelim_map.txt" ]; then
     echo "No preliminary seqid/taxid mapping files found, aborting."
     exit 1


### PR DESCRIPTION
Addressing issue #568, that kraken2-build doesn't follow symlinked subdirectories when searching for input fna or faa files. Added -L option to the find commands. This allows them to traverse symlinks in the library directory. It is particularly useful when building multiple databases with shared reference sequences, as symlinking may be preferable in this case to save space.