### PR TITLE
Initial commit of dustmasker for kraken2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,4 +23,8 @@ else(OPENMP_FOUND)
     message("ERROR: OpenMP could not be found.")
 endif(OPENMP_FOUND)
 
+find_package(Threads REQUIRED)
+find_package(ZLIB REQUIRED)
+include_directories(${ZLIB_INCLUDE_DIRS})
+
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,3 +42,9 @@ add_executable(lookup_accession_numbers
         mmap_file.cc
         omp_hack.cc
         utilities.cc)
+
+add_executable(dustmasker
+        dustmasker.cc
+        seqreader.cc)
+
+target_link_libraries(dustmasker ${ZLIB_LIBRARIES} Threads::Threads)

--- a/src/Makefile
+++ b/src/Makefile
@@ -24,6 +24,7 @@ omp_hack.o: omp_hack.cc omp_hack.h
 reports.o: reports.cc reports.h kraken2_data.h
 aa_translate.o: aa_translate.cc aa_translate.h
 utilities.o: utilities.cc utilities.h
+dustmasker.o: dustmasker.cc gzstream.h threadpool.h
 
 classify.o: classify.cc kraken2_data.h kv_store.h taxonomy.h seqreader.h mmscanner.h compact_hash.h aa_translate.h reports.h utilities.h readcounts.h
 dump_table.o: dump_table.cc compact_hash.h taxonomy.h mmscanner.h kraken2_data.h reports.h
@@ -45,3 +46,6 @@ dump_table: dump_table.o mmap_file.o compact_hash.o omp_hack.o taxonomy.o report
 
 lookup_accession_numbers: lookup_accession_numbers.o mmap_file.o omp_hack.o utilities.o
 	$(CXX) $(CXXFLAGS) -o $@ $^
+
+dustmasker: dustmasker.o seqreader.o
+	$(CXX) $(CXXFLAGS) -o $@ $^ -lz -pthread

--- a/src/build_db.cc
+++ b/src/build_db.cc
@@ -223,7 +223,7 @@ void ProcessSequences(const Options &opts,
       auto all_sequence_ids = ExtractNCBISequenceIDs(sequence.header);
       taxid_t taxid = 0;
       for (auto &seqid : all_sequence_ids) {
-        if (ID_to_taxon_map.count(seqid) == 0) continue;
+        if (ID_to_taxon_map.count(seqid) == 0 || ID_to_taxon_map.at(seqid) == 0) continue;
         auto ext_taxid = ID_to_taxon_map.at(seqid);
         taxid = taxonomy.LowestCommonAncestor(taxid, taxonomy.GetInternalID(ext_taxid));
       }

--- a/src/build_db.cc
+++ b/src/build_db.cc
@@ -180,7 +180,7 @@ void ProcessSequencesFast(const Options &opts,
         auto all_sequence_ids = ExtractNCBISequenceIDs(sequence.header);
         taxid_t taxid = 0;
         for (auto &seqid : all_sequence_ids) {
-          if (ID_to_taxon_map.count(seqid) == 0) continue;
+          if (ID_to_taxon_map.count(seqid) == 0 || ID_to_taxon_map.at(seqid) == 0) continue;
           auto ext_taxid = ID_to_taxon_map.at(seqid);
           taxid = taxonomy.LowestCommonAncestor(taxid, taxonomy.GetInternalID(ext_taxid));
         }
@@ -430,7 +430,8 @@ void ReadIDToTaxonMap(map<string, taxid_t> &id_map, string &filename) {
     istringstream iss(line);
     iss >> seq_id;
     iss >> taxid;
-    id_map[seq_id] = taxid;
+    if (taxid)
+      id_map[seq_id] = taxid;
   }
 }
 

--- a/src/dustmasker.cc
+++ b/src/dustmasker.cc
@@ -1,0 +1,322 @@
+/*
+ * Symmetric Dustmasker mostly based on a similarly named implementation
+ * by Heng Li as part of the minimap project.
+ */
+
+#include <deque>
+#include <functional>
+#include <future>
+#include <iostream>
+#include <string>
+#include <vector>
+#include <queue>
+
+#include <ctype.h>
+#include <getopt.h>
+#include <string.h>
+#include <zlib.h>
+
+#include "gzstream.h"
+#include "seqreader.h"
+#include "threadpool.h"
+
+using namespace kraken2;
+
+uint8_t asc2dna[] = {
+	/*   0 */ 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+	/*  16 */ 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+	/*  32 */ 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+	/*                                               - */
+	/*  48 */ 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+	/*  64 */ 4, 0, 4, 1, 4, 4, 4, 2, 4, 4, 4, 4, 4, 4, 4, 4,
+	       /*    A  B  C  D        G  H        K     M  N */
+	/*  80 */ 4, 4, 4, 4, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+	       /*       R  S  T  U  V  W     Y */
+	/*  96 */ 4, 0, 4, 1, 4, 4, 4, 2, 4, 4, 4, 4, 4, 4, 4, 4,
+	       /*    a  b  c  d        g  h        k     m  n */
+	/* 112 */ 4, 4, 4, 4, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+	       /*       r  s  t  u  v  w     y */
+	/* 128 */ 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+	/* 144 */ 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+	/* 160 */ 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+	/* 176 */ 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+	/* 192 */ 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+	/* 208 */ 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+	/* 224 */ 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+	/* 240 */ 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+};
+
+struct PerfectInterval {
+        int start;
+        int finish;
+        int left;
+        int right;
+};
+
+struct MaskRange {
+        int start;
+        int finish;
+};
+
+struct SDust {
+        SDust(): rw(0), rv(0), l(0) {
+                memset(cv, 0, 64 * sizeof(int));
+                memset(cw, 0, 64 * sizeof(int));
+        }
+
+        void reset() {
+                kmers.clear();
+                perfectIntervals.clear();
+                ranges.clear();
+                memset(cw, 0, 64 * sizeof(int));
+                memset(cv, 0, 64 * sizeof(int));
+                l = rv = rv = 0;
+        }
+
+        std::deque<int> kmers;
+        std::vector<PerfectInterval> perfectIntervals;
+        std::vector<MaskRange> ranges;
+        Sequence seq;
+        int cw[64];
+        int cv[64];
+        int rw;
+        int rv;
+        int l;
+};
+
+int windowSize = 64;
+int threshold = 20;
+std::function<int(int)> maskChar = tolower;
+
+void usage(const char *prog) {
+        std::cerr << "usage: " << prog << " [-T threshold] [-W window size] [-l line length] [-r char] [-t threads]"
+                  << std::endl;
+        exit(1);
+}
+
+void shiftWindow(SDust &sd, int t) {
+        int s;
+        if (sd.kmers.size() >= windowSize - 2) {
+                s = sd.kmers.front();
+                sd.kmers.pop_front();
+                sd.rw -= --sd.cw[s];
+                if (sd.l > sd.kmers.size()) {
+                        --sd.l;
+                        sd.rv -= --sd.cv[s];
+                }
+        }
+        sd.kmers.push_back(t);
+        sd.l++;
+        sd.rw += sd.cw[t]++;
+        sd.rv += sd.cv[t]++;
+        if (sd.cv[t] * 10 > threshold * 2) {
+                do {
+                        s = sd.kmers.at(sd.kmers.size() - sd.l);
+                        sd.rv -= --sd.cv[s];
+                        sd.l--;
+                } while (s != t);
+        }
+}
+
+void saveMaskedRegions(SDust &sd, int windowStart) {
+        bool saved = false;
+        if (sd.perfectIntervals.size() == 0
+            || sd.perfectIntervals.back().start >= windowStart)
+                return;
+        PerfectInterval &p = sd.perfectIntervals.back();
+        if (!sd.ranges.empty()) {
+                int start = sd.ranges.back().start;
+                int finish = sd.ranges.back().finish;
+                if (p.start <= finish) {
+                        sd.ranges.back() = MaskRange { start, std::max(p.finish, finish) };
+                        saved = true;
+                }
+        }
+        if (!saved)
+                sd.ranges.push_back(MaskRange { p.start, p.finish});
+        while (!sd.perfectIntervals.empty()
+               && sd.perfectIntervals.back().start < windowStart)
+                sd.perfectIntervals.pop_back();
+}
+
+void findPerfect(SDust &sd, int windowStart) {
+        int cv[64];
+        int maxLeft = 0;
+        int maxRight = 0;
+        int newLeft = 0;
+        int newRight = sd.rv;
+
+        memcpy(cv, sd.cv, 64 * sizeof(int));
+        for (int i = sd.kmers.size() - sd.l - 1; i >= 0; --i) {
+                int j;
+                int kmer = sd.kmers.at(i);
+                newRight += cv[kmer]++;
+                newLeft = sd.kmers.size() - i - 1;
+                if (newRight * 10 > threshold * newLeft) {
+                        for (j = 0; j < sd.perfectIntervals.size() && sd.perfectIntervals[j].start >= i + windowStart; ++j) {
+                                PerfectInterval &p = sd.perfectIntervals[j];
+                                if (maxRight == 0 || p.right * maxLeft > maxRight * p.left) {
+                                        maxLeft = p.left;
+                                        maxRight = p.right;
+                                }
+                        }
+                        if (maxRight == 0 || newRight * maxLeft >= maxRight * newLeft) {
+                                maxLeft = newLeft;
+                                maxRight = newRight;
+                                PerfectInterval p;
+                                p.start = i + windowStart;
+                                p.finish = sd.kmers.size() + 2 + windowStart;
+                                p.left = newLeft;
+                                p.right = newRight;
+                                auto position = sd.perfectIntervals.begin() + j;
+                                sd.perfectIntervals.insert(position, p);
+                        }
+                }
+        }
+}
+
+void runSymmetricDust(SDust &sd, char *seq, size_t size, int offset) {
+        int triplet = 0;
+        int windowStart;
+        for (int i = 0, l = 0; i < size; i++) {
+                int base = asc2dna[(int)seq[i]];
+                if (base < 4) {
+                        l++;
+                        triplet = (triplet << 2 | base) & 63;
+                        if (l >= 3) {
+                                windowStart = std::max(l - windowSize, 0);
+                                saveMaskedRegions(sd, windowStart);
+                                shiftWindow(sd, triplet);
+                                if (sd.rw * 10 > sd.l * threshold)
+                                        findPerfect(sd, windowStart);
+                        }
+                }
+        }
+        while (!sd.perfectIntervals.empty())
+                saveMaskedRegions(sd, windowStart++);
+}
+
+void printFasta(Sequence seq, std::ostream& out, int width) {
+        out.write(&seq.header[0], seq.header.size());
+        out << '\n';
+        for (size_t i = 0; i < seq.seq.size(); i += width) {
+                if (i + width >= seq.seq.size())
+                        width = seq.seq.size() - i;
+                out.write(&seq.seq[i], width);
+                out << '\n';
+        }
+}
+
+SDust *mask(SDust *sd) {
+        size_t i = 0; // ns = 0;
+        std::string &seq = sd->seq.seq;
+
+        // for (i = 0; i < seq.size() && asc2dna[seq[i]] == 4; i++)
+        //         seq[i] = maskChar(seq[i]);
+        for (; i < seq.size(); i++) {
+                if (asc2dna[(int)seq[i]] != 4) {
+                        // if (ns >= windowSize) {
+                        //         for (; ns > 0; --ns) {
+                        //                 seq[i - ns] = maskChar(seq[i - ns]);
+                        //         }
+                        // }
+                        // ns = 0;
+                        int start = i;
+                        for (;;) {
+                                seq[i] = toupper(seq[i]);
+                                if ((i+1) == seq.size()
+                                    || asc2dna[(int)seq[i+1]] == 4)
+                                        break;
+                                i++;
+                        }
+                        char *s = &seq[0] + start;
+                        runSymmetricDust(*sd, s, i - start + 1, start);
+                        for (size_t j = 0; j < sd->ranges.size(); j++) {
+                                for (size_t i = sd->ranges[j].start; i < sd->ranges[j].finish; i++)
+                                        s[i] = maskChar(s[i]);
+                        }
+                        sd->ranges.clear();
+                // } else {
+                //         ns++;
+                }
+        }
+        // while (asc2dna[seq[--i]] == 4)
+        //         seq[i] = maskChar(seq[i]);
+        return sd;
+}
+
+int main(int argc, char **argv) {
+        int ch;
+        int lineLength = 72;
+        int threads = 1;
+        std::string buffer;
+        const char *prog = "dustmasker";
+        while ((ch = getopt(argc, argv, "W:T:l:t:r:")) != -1) {
+                switch (ch) {
+                case 'W':
+                        windowSize = atoi(optarg);
+                        break;
+                case 'T':
+                        threshold = atoi(optarg);
+                        break;
+                case 'l':
+                        lineLength = atoi(optarg);
+                        break;
+                case 't':
+                        threads = atoi(optarg);
+                        break;
+                case 'r': {
+                        if (strlen(optarg) != 1) {
+                                std::cerr << prog << ": -r expects a single character, "
+                                          << optarg << " given." << std::endl;
+                                usage(prog);
+                        }
+                        int r = optarg[0];
+                        maskChar = [=](char c) { return r; };
+                        break;
+                }
+                default:
+                        usage(prog);
+                }
+        }
+        argc -= optind;
+        argv += optind;
+
+        if (argc > 0) {
+                std::cerr << prog << ": reads from stdin and writes to stdout"
+                          << std::endl;
+                usage(prog);
+        }
+        gzistream is("/dev/stdin");
+        std::vector<SDust *> sds(threads);
+        for (size_t i = 0; i < sds.size(); i++) {
+                sds[i] = new SDust();
+        }
+        thread_pool pool(threads - 1);
+        std::queue<std::future<SDust *>> tasks;
+        for (SDust *sd = sds.back(); BatchSequenceReader::ReadNextSequence(is, sd->seq, buffer); sd = sds.back()) {
+                sds.pop_back();
+                if (threads > 1) {
+                        tasks.push(pool.submit(mask, sd));
+                        while (sds.empty()) {
+                                sd = tasks.front().get();
+                                printFasta(sd->seq, std::cout, lineLength);
+                                tasks.pop();
+                                sd->reset();
+                                sds.push_back(sd);
+                        }
+                } else {
+                        mask(sd);
+                        printFasta(sd->seq, std::cout, lineLength);
+                        sds.push_back(sd);
+                }
+        }
+        while (!tasks.empty()) {
+                SDust *sd = tasks.front().get();
+                printFasta(sd->seq, std::cout, lineLength);
+                tasks.pop();
+        }
+        for (size_t i = 0; i < sds.size(); i++)
+                delete(sds[i]);
+        std::cout.flush();
+}

--- a/src/gzstream.h
+++ b/src/gzstream.h
@@ -1,0 +1,129 @@
+#ifndef __GZSTREAM_H__
+#define __GZSTREAM_H__
+
+#include <assert.h>
+#include <zlib.h>
+#include <ios>
+#include <locale>
+#include <streambuf>
+#include <iostream>
+#include <string>
+#include <vector>
+
+template<typename charT, typename traits = std::char_traits<char>>
+class basic_gzbuf : public std::basic_streambuf<charT, traits> {
+        typedef charT char_type;
+        typedef traits traits_type;
+        typedef typename traits::int_type int_type;
+        typedef typename traits::pos_type pos_type;
+        typedef typename traits::off_type off_type;
+
+public:
+        basic_gzbuf(const char *filename);
+        basic_gzbuf(const std::vector<std::string> *filenames);
+        void open(const char *filename);
+        void close();
+        virtual ~basic_gzbuf() {
+                close();
+        }
+
+
+protected:
+        basic_gzbuf() {
+                delete[] buffer_;
+        }
+        virtual int_type underflow();
+        // virtual basic_gzbuf *setbuf(char_type *buf, std::streamsize size);
+
+private:
+        char_type *buffer_;
+        std::streamsize size_;
+        const std::vector<std::string> *filenames_;
+        size_t file_idx_;
+        static const int DEFAULT_BUFSIZ = 1024 * 8;
+        gzFile f;
+};
+
+template<typename charT, typename traits>
+basic_gzbuf<charT, traits>::basic_gzbuf(const char *filename)
+        : buffer_(new char_type[DEFAULT_BUFSIZ]),
+          size_(DEFAULT_BUFSIZ),
+          filenames_(NULL)
+{
+        this->open(filename);
+        this->setg(buffer_, buffer_ + size_, buffer_ + size_);
+}
+
+template<typename charT, typename traits>
+basic_gzbuf<charT, traits>::basic_gzbuf(const std::vector<std::string> *filenames)
+        : buffer_(new char_type[DEFAULT_BUFSIZ]),
+          size_(DEFAULT_BUFSIZ),
+          filenames_(filenames),
+          file_idx_(0)
+{
+        assert(!filenames->empty());
+        this->open(filenames_->at(file_idx_).c_str());
+        file_idx_++;
+        this->setg(buffer_, buffer_ + size_, buffer_ + size_);
+}
+
+template<typename charT, typename traits>
+typename basic_gzbuf<charT, traits>::int_type
+basic_gzbuf<charT, traits>::underflow() {
+        int read = gzread(f, buffer_, size_);
+        if (read == 0 && filenames_ != NULL && file_idx_ < filenames_->size()) {
+                close();
+                open(filenames_->at(file_idx_++).c_str());
+                read = gzread(f, buffer_, size_);
+        }
+        this->setg(buffer_, buffer_, buffer_ + read);
+        if (this->egptr() == this->gptr())
+                return traits::eof();
+        else
+                return traits::to_int_type(*this->gptr());
+}
+
+template<typename charT, typename traits>
+void basic_gzbuf<charT, traits>::open(const char *filename) {
+        f = gzopen(filename, "rb");
+        if (f == NULL) {
+                std::cerr << "Unable to open \"" << filename << "\" for reading"
+                          << std::endl;
+                exit(1);
+        }
+        gzbuffer(f, DEFAULT_BUFSIZ);
+}
+
+template<typename charT, typename traits>
+void basic_gzbuf<charT, traits>::close() {
+        if (f != NULL)
+                gzclose(f);
+}
+
+template<typename charT, typename traits = std::char_traits<charT>>
+class basic_gzistream : public std::basic_istream<charT, traits>
+{
+public:
+        typedef charT char_type;
+        typedef traits traits_type;
+        typedef typename traits::int_type int_type;
+        typedef typename traits::pos_type pos_type;
+        typedef typename traits::off_type off_type;
+
+        basic_gzistream(const char *filename) : std::basic_istream<charT, traits>(NULL),
+                                                sb(filename)
+        {
+                this->init(&sb);
+        }
+
+        basic_gzistream(const std::vector<std::string> *filenames): std::basic_istream<charT, traits>(NULL),
+                                                              sb(filenames)
+        {
+                this->init(&sb);
+        }
+private:
+        basic_gzbuf<char_type, traits_type> sb;
+};
+
+typedef basic_gzistream<char> gzistream;
+#endif

--- a/src/threadpool.h
+++ b/src/threadpool.h
@@ -1,0 +1,133 @@
+#ifndef _THREAD_POOL_H_
+#define _THREAD_POOL_H_
+
+#include <atomic>
+#include <condition_variable>
+#include <functional>
+#include <future>
+#include <memory>
+#include <map>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <vector>
+
+template<typename T>
+class threadsafe_queue {
+private:
+	mutable std::mutex mut;
+	std::queue<T> data_queue;
+
+public:
+	threadsafe_queue() {}
+
+	void push(T &&new_value) {
+		std::lock_guard<std::mutex> lk(mut);
+		data_queue.emplace(new_value);
+	}
+
+	bool try_pop(T& value) {
+		std::lock_guard<std::mutex> lk(mut);
+		if (data_queue.empty())
+			return false;
+		value = std::move(data_queue.front());
+		data_queue.pop();
+		return true;
+	}
+
+	size_t size() {
+		std::lock_guard<std::mutex> lk(mut);
+		return data_queue.size();
+	}
+};
+
+class thread_pool
+{
+	std::atomic_bool done;
+	int nthreads;
+        std::map<std::thread::id, int> thread_id;
+	threadsafe_queue<std::function<void()>> work_queue;
+	std::vector<std::thread> threads;
+        std::condition_variable cv;
+        std::mutex m;
+
+	void worker_thread() {
+		while (!done) {
+			std::function<void()> task;
+                        if (work_queue.try_pop(task)) {
+				task();
+                        } else {
+                                std::unique_lock<std::mutex> lock(m);
+                                cv.wait(lock, [&] {return work_queue.size() != 0 || done; });
+                        }
+                }
+	}
+public:
+	thread_pool(int nthr):
+		done(false), nthreads(nthr)
+		{
+			try {
+                                for (int i = 0; i < nthreads; ++i) {
+                                        threads.emplace_back(
+                                                std::thread(&thread_pool::worker_thread, this));
+                                        thread_id[threads[i].get_id()] = i;
+                                }
+                        } catch (...) {
+				done = true;
+				throw;
+			}
+		}
+	~thread_pool() {
+                while (work_queue.size() != 0) ;
+		done = true;
+                std::unique_lock<std::mutex> lock(m);
+                cv.notify_all();
+                lock.unlock();
+		for (std::thread& thread: threads) {
+			thread.join();
+		}
+
+	}
+
+	template<typename Function, typename... Args>
+	std::future<typename std::result_of<Function(Args...)>::type>
+	submit(Function &&f, Args&&... args) {
+		using result_type = typename std::result_of<Function(Args...)>::type;
+		auto task = std::make_shared<std::packaged_task<result_type()>>(std::bind(std::forward<Function>(f), std::forward<Args>(args)...));
+		std::future<result_type> res(task->get_future());
+                work_queue.push([task] { (*task)(); });
+                std::unique_lock<std::mutex> lock(m);
+                cv.notify_one();
+                return res;
+	}
+
+        int size() {
+                return nthreads;
+        }
+
+        int thread_id_to_int(std::thread::id id) {
+                return thread_id[id];
+        }
+
+        template<typename T, typename Function>
+        void parallel_for(T start, T end, T stride, Function &&f) {
+                T range = end - start;
+                T block_size = range / (nthreads);
+                T block_start = start;
+                T block_end = block_start + block_size;
+                if (block_size == 0)
+                        block_end = end;
+                std::vector<std::future<void>> res;
+                while (block_start < end) {
+                        res.emplace_back(submit(f, block_start, block_end, stride));
+                        block_start = block_end;
+                        block_end = block_end + block_size;
+                        if (block_end >= end)
+                                block_end = end;
+                }
+                for (size_t i = 0; i < res.size(); i++)
+                        res[i].get();
+        }
+};
+
+#endif


### PR DESCRIPTION
This commit adds functionality for a new nucleotide masker. This implementation is mostly a rewrite of `sdust` masker by Heng Li, part of the `minimap2` project, in C++ with multithreading support. The implementation differs from NCBI's masker in that it entirely ignores `N`s. This difference can produce slight differences in the masking output but *should* not affect Kraken2's database building. The masker also provides the option for replacing masked characters e.g. this command from `mask_low_complexity_regions.sh`:

`$MASKER -in $file -outfmt fasta | sed -e '/^>/!s/[a-z]/x/g` => `cat $file | $MASKER -r x`