### PR TITLE
Improve resilience of rsync of library data

### DIFF
--- a/scripts/rsync_from_ncbi.pl
+++ b/scripts/rsync_from_ncbi.pl
@@ -35,18 +35,18 @@ while (<>) {
   next if /^#/;
   chomp;
   my @fields = split /\t/;
-  my ($taxid, $asm_level, $ftp_path) = @fields[5, 11, 19];
+  my ($taxid, $asm_level, $file_path) = @fields[5, 11, 19];
   # Possible TODO - make the list here configurable by user-supplied flags
   next unless grep {$asm_level eq $_} ("Complete Genome", "Chromosome");
-  next if $ftp_path eq "na";  # Skip if no provided path
+  next if $file_path eq "na";  # Skip if no provided path
 
-  my $full_path = $ftp_path . "/" . basename($ftp_path) . $suffix;
+  my $full_path = $file_path . "/" . basename($file_path) . $suffix;
   # strip off server/leading dir name to allow --files-from= to work w/ rsync
   # also allows filenames to just start with "all/", which is nice
-  my $prefix = $use_ftp ? "ftp" : "https";
+  my $protocol = $use_ftp ? "ftp" : "https";
 
-  if (! ($full_path =~ s#^${prefix}://${qm_server}${qm_server_path}/##)) {
-    die "$PROG: unexpected FTP path (new server?) for $ftp_path\n";
+  if (! ($full_path =~ s#^${protocol}://${qm_server}${qm_server_path}/##)) {
+    die "$PROG: unexpected $protocol file path (new server? wrong protocol?) for $file_path\n";
   }
   $manifest{$full_path} = $taxid;
 }

--- a/scripts/rsync_from_ncbi.pl
+++ b/scripts/rsync_from_ncbi.pl
@@ -43,7 +43,9 @@ while (<>) {
   my $full_path = $ftp_path . "/" . basename($ftp_path) . $suffix;
   # strip off server/leading dir name to allow --files-from= to work w/ rsync
   # also allows filenames to just start with "all/", which is nice
-  if (! ($full_path =~ s#^ftp://${qm_server}${qm_server_path}/##)) {
+  my $prefix = $use_ftp ? "ftp" : "https";
+
+  if (! ($full_path =~ s#^${prefix}://${qm_server}${qm_server_path}/##)) {
     die "$PROG: unexpected FTP path (new server?) for $ftp_path\n";
   }
   $manifest{$full_path} = $taxid;


### PR DESCRIPTION
This change accomplishes two things:
1. Adds the rsync dry run to all downloads.
2. Fixes an incompatibility/ambiguity with FTP vs. `rsync` being selected as the download method, and the resulting server/protocol check of downloads.

I've tested locally running an rsync download, it appears to behave appropriately.