### PR TITLE
Fix issue with Silva having domain and superkingdom taxonomic ranks both converted to superkingdom (D) in Kraken

### DIFF
--- a/scripts/build_silva_taxonomy.pl
+++ b/scripts/build_silva_taxonomy.pl
@@ -32,6 +32,7 @@ while (<>) {
     if (! defined $parent_id) {
       die "$PROG: orphan error, line $.\n";
     }
+    $rank = "major_clade" if $rank eq "superkingdom";
     $rank = "superkingdom" if $rank eq "domain";
     print NAMES "$node_id\t|\t$display_name\t|\t-\t|\tscientific name\t|\n";
     print NODES "$node_id\t|\t$parent_id\t|\t$rank\t|\t-\t|\n";


### PR DESCRIPTION
Addressing issue #739.
`superkingdom` is converted to `major_clade`.
`domain` is still converted to `superkingdom`.
This avoids having the same taxonomic rank (`D`) apprearing twice in the classification on Kraken reports.