### PR TITLE
add more deps to makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -16,17 +16,17 @@ clean:
 	rm -f *.o $(PROGS)
 
 taxonomy.o: taxonomy.cc taxonomy.h mmap_file.h
-hyperloglogplus.o: hyperloglogplus.cc hyperloglogplus.h
+hyperloglogplus.o: hyperloglogplus.cc hyperloglogplus.h hyperloglogplus-bias.h
 mmap_file.o: mmap_file.cc mmap_file.h
-compact_hash.o: compact_hash.cc compact_hash.h kv_store.h mmap_file.h kraken2_data.h
+compact_hash.o: compact_hash.cc compact_hash.h kv_store.h mmap_file.h kraken2_data.h readcounts.h hyperloglogplus.h
 mmscanner.o: mmscanner.cc mmscanner.h
 seqreader.o: seqreader.cc seqreader.h
 omp_hack.o: omp_hack.cc omp_hack.h
-reports.o: reports.cc reports.h kraken2_data.h
+reports.o: reports.cc reports.h kraken2_data.h taxonomy.h readcounts.h hyperloglogplus.h
 aa_translate.o: aa_translate.cc aa_translate.h
 utilities.o: utilities.cc utilities.h
 
-classify.o: classify.cc kraken2_data.h kv_store.h taxonomy.h seqreader.h mmscanner.h compact_hash.h aa_translate.h reports.h utilities.h readcounts.h
+classify.o: classify.cc kraken2_data.h kv_store.h taxonomy.h seqreader.h mmscanner.h compact_hash.h aa_translate.h reports.h utilities.h readcounts.h hyperloglogplus.h
 dump_table.o: dump_table.cc compact_hash.h taxonomy.h mmscanner.h kraken2_data.h reports.h
 estimate_capacity.o: estimate_capacity.cc kv_store.h mmscanner.h seqreader.h utilities.h
 build_db.o: build_db.cc taxonomy.h mmscanner.h seqreader.h compact_hash.h kv_store.h kraken2_data.h utilities.h


### PR DESCRIPTION
I was trying to build kraken with bazel and noticed that some dependencies aren't properly mapped out.

I'm not sure how this builds with `make` as-is but the dependencies here seem valid.

Anyway, it still builds with these changes, but my other bazel build works too.

I'm interested to know if the Makefile has fallen out of date, why it works as-is, and whether these changes look valid.