### PR TITLE
implement @togop's fix for Rsync error: issue 518

### DIFF
--- a/scripts/rsync_from_ncbi.pl
+++ b/scripts/rsync_from_ncbi.pl
@@ -43,7 +43,7 @@ while (<>) {
   my $full_path = $ftp_path . "/" . basename($ftp_path) . $suffix;
   # strip off server/leading dir name to allow --files-from= to work w/ rsync
   # also allows filenames to just start with "all/", which is nice
-  if (! ($full_path =~ s#^(?:ftp|https)://${qm_server}${qm_server_path}/##)) {
+  if (! ($full_path =~ s#^((ht|f)tp(s?))://${qm_server}${qm_server_path}/##)) {
     die "$PROG: unexpected FTP path (new server?) for $ftp_path\n";
   }
   $manifest{$full_path} = $taxid;


### PR DESCRIPTION
I was not able to download bacteria database by FTP or rsync, per recent issues 518 and 797.

I implemented @togop 's fix to successfully allow for trying an HTTPS/FTP link, which will solve this issue.