### PR TITLE
Fix strip trailing slash from NCBI ftp_path to prevent malformed download URLs

### DIFF
--- a/scripts/k2
+++ b/scripts/k2
@@ -971,7 +971,7 @@ def make_manifest_from_assembly_summary(
         if line.startswith("#"):
             continue
         fields = line.strip().split("\t")
-        taxid, asm_level, ftp_path = fields[5], fields[11], fields[19]
+        taxid, asm_level, ftp_path = fields[5], fields[11], fields[19].rstrip("/")
         if not re.match(asm_level_regex, asm_level, re.IGNORECASE):
             continue
         if ftp_path == "na":
@@ -1382,6 +1382,7 @@ def map_accessions_to_url_parallel(args, accessions):
 
 
 def get_download_path(resource_link, protein):
+    resource_link = resource_link.rstrip("/")
     dir = os.path.basename(resource_link)
     filename = dir + "_genomic.fna.gz"
     resource_link += "/"


### PR DESCRIPTION
### Description
This PR fixes the download failure when fetching databases (like `viral`) whose NCBI `assembly_summary.txt` contains a trailing slash in the `ftp_path` column. 

**Fixes #1014** 

### Changes Made
* Added `.rstrip("/")` to `ftp_path` extraction in `make_manifest_from_assembly_summary` to ensure `os.path.basename()` correctly extracts the base directory name instead of returning an empty string.
* Applied the same `.rstrip("/")` safety measure to `resource_link` in `get_download_path`.

### Testing
- [x] Verified that strings with and without trailing slashes are parsed correctly.