### PR TITLE
Fix trailing slash in NCBI FTP URLs causing empty filenames in taxid downloads

### DIFF
--- a/scripts/k2
+++ b/scripts/k2
@@ -1433,6 +1433,7 @@ def map_accessions_to_url_parallel(args, accessions):
 
 
 def get_download_path(resource_link, protein):
+    resource_link = resource_link.rstrip("/")
     dir = os.path.basename(resource_link)
     filename = dir + "_genomic.fna.gz"
     resource_link += "/"


### PR DESCRIPTION
The NCBI datasets API returns `resource_link` values with trailing slashes, e.g. `https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/001/635/GCF_000001635.27_GRCm39/`, causing `os.path.basename` to return an empty string and producing invalid filenames like '_genomic.fna.gz'. A simple `rstrip("/")` fixes this.