### PR TITLE
Fix spurious "capacity exceeded" abort in CompareAndSet after a successful insert

### DIFF
--- a/src/compact_hash.h
+++ b/src/compact_hash.h
@@ -334,6 +334,8 @@ bool CompactHashTable<Cell>::CompareAndSet
       }
     }
     omp_unset_lock(&zone_locks_[zone]);
+    if (search_successful)
+      break;
     if (step == 0)
       step = second_hash(hc);
     idx += step;


### PR DESCRIPTION
CompareAndSet advanced the probe index and ran the table-exhausted check at the end of every loop iteration, including the one in which the search/insert had already succeeded. When the double-hash step was 0 mod capacity, the advanced index wrapped back to first_idx and the program aborted via errx -- even for a successful insert into an otherwise empty table. Break out of the loop once the target slot is found, so the post-success advance and wrap check no longer run. Behavior is unchanged for all other keys; Get/FindIndex were already unaffected because they return/break rather than errx.