### PR TITLE
Fix double-free of index data at classify exit

### DIFF
--- a/src/classify.cc
+++ b/src/classify.cc
@@ -417,9 +417,7 @@ void ClassifyDaemon(Options opts) {
   free(cmdline);
 
   for (auto kv : indexes) {
-    delete kv.second->cht;
-    delete kv.second->taxonomy;
-    delete kv.second;
+    delete kv.second;  // ~IndexData() frees cht + taxonomy (was double-free)
   }
 }
 
@@ -432,9 +430,7 @@ int main(int argc, char **argv) {
   } else {
     IndexData *index_data = load_index(opts);
     classify(opts, index_data);
-    delete index_data->cht;
-    delete index_data->taxonomy;
-    delete index_data;
+    delete index_data;  // ~IndexData() frees cht + taxonomy (was double-free)
   }
 
   return 0;


### PR DESCRIPTION
## Summary

`IndexData`'s destructor already deletes its owned `cht` and `taxonomy` members, but both teardown paths in `classify.cc` delete those members a second time before deleting the `IndexData` object:

- **`main()`** (non-daemon path): after `classify()` returns, it deletes `index_data->cht` and `index_data->taxonomy`, then `index_data`.
- **`ClassifyDaemon()`** cleanup loop: it deletes `kv.second->cht` and `kv.second->taxonomy`, then `kv.second`.

In both cases, deleting the object runs `~IndexData()`, which frees `cht` and `taxonomy` again — a double-free (undefined behavior). It can crash or corrupt the heap at process exit depending on platform/allocator; the daemon path hits it on every shutdown.

## Fix

Delete only the `IndexData` object in both places and let its destructor release `cht` and `taxonomy` exactly once. One file, two sites; no change to classification behavior or output.

## Verifying

Building with `-fsanitize=address` and running `classify` (or stopping a `--use-daemon` session) surfaces the double-free on the original code and shows it resolved here.
