### PR TITLE
Multiple performance improvements to classify

### DIFF
--- a/src/classify.cc
+++ b/src/classify.cc
@@ -34,6 +34,14 @@ static const taxid_t MATE_PAIR_BORDER_TAXON = TAXID_MAX;
 static const taxid_t READING_FRAME_BORDER_TAXON = TAXID_MAX - 1;
 static const taxid_t AMBIGUOUS_SPAN_TAXON = TAXID_MAX - 2;
 
+// Token stream used to defer minimizer lookups in ClassifySequence so they can be
+// resolved in one prefetched batch. kind selects how replay rebuilds taxa[]/counts;
+// key_idx indexes the distinct-minimizer lookup arrays for TOK_LOOKUP. uint32_t is
+// ample: it counts distinct minimizers in a single read pair (far below 2^32).
+enum MinTokKind { TOK_LOOKUP, TOK_SKIP, TOK_REPEAT, TOK_AMBIG,
+                  TOK_BORDER_MATE, TOK_BORDER_FRAME };
+struct MinToken { uint8_t kind; uint32_t key_idx; };
+
 // template <typename Cell>
 // using IndexData = std::tuple<IndexOptions, Taxonomy, CompactHashTable<Cell> *>;
 
@@ -781,6 +789,15 @@ taxid_t ClassifySequence(Sequence &dna, Sequence &dna2, ostringstream &koss,
   auto frame_ct = opts.use_translated_search ? 6 : 1;
   int64_t minimizer_hit_groups = 0;
 
+  // Phase 1: scan minimizers for the read pair into a token stream, deferring the
+  // memory-latency-bound hash lookups. Lookup-vs-repeat-vs-ambiguous is decided
+  // purely from minimizer values (independent of taxon), exactly as the original
+  // consecutive-dedup did, so phase 3 reproduces identical taxa[]/counts.
+  static thread_local std::vector<uint64_t> lookup_keys;
+  static thread_local std::vector<MinToken> tok_stream;
+  lookup_keys.clear();
+  tok_stream.clear();
+
   for (int mate_num = 0; mate_num < 2; mate_num++) {
     if (mate_num == 1 && ! opts.paired_end_processing)
       break;
@@ -797,52 +814,81 @@ taxid_t ClassifySequence(Sequence &dna, Sequence &dna2, ostringstream &koss,
         scanner.LoadSequence(mate_num == 0 ? dna.seq : dna2.seq);
       }
       uint64_t last_minimizer = UINT64_MAX;
-      taxid_t last_taxon = TAXID_MAX;
       while ((minimizer_ptr = scanner.NextMinimizer()) != nullptr) {
-        taxid_t taxon;
         if (scanner.is_ambiguous()) {
-          taxon = AMBIGUOUS_SPAN_TAXON;
+          tok_stream.push_back({TOK_AMBIG, 0});
         }
-        else {
-          if (*minimizer_ptr != last_minimizer) {
-            bool skip_lookup = false;
-            if (idx_opts.minimum_acceptable_hash_value) {
-              if (MurmurHash3(*minimizer_ptr) < idx_opts.minimum_acceptable_hash_value)
-                skip_lookup = true;
-            }
-            taxon = 0;
-            if (! skip_lookup)
-              taxon = hash->Get(*minimizer_ptr);
-            last_taxon = taxon;
-            last_minimizer = *minimizer_ptr;
-            // Increment this only if (a) we have DB hit and
-            // (b) minimizer != last minimizer
-            if (taxon) {
-              minimizer_hit_groups++;
-              // New minimizer should trigger registering minimizer in RC/HLL
-              if (!opts.report_filename.empty()) {
-                curr_taxon_counts[taxon].add_kmer(scanner.last_minimizer());
-              }
-            }
+        else if (*minimizer_ptr != last_minimizer) {
+          last_minimizer = *minimizer_ptr;
+          bool skip_lookup = idx_opts.minimum_acceptable_hash_value &&
+              MurmurHash3(*minimizer_ptr) < idx_opts.minimum_acceptable_hash_value;
+          if (skip_lookup) {
+            tok_stream.push_back({TOK_SKIP, 0});
           }
           else {
-            taxon = last_taxon;
-          }
-          if (taxon) {
-            if (opts.quick_mode && minimizer_hit_groups >= opts.minimum_hit_groups) {
-              call = taxon;
-              goto finished_searching;  // need to break 3 loops here
-            }
-            hit_counts[taxon]++;
+            tok_stream.push_back({TOK_LOOKUP, (uint32_t) lookup_keys.size()});
+            lookup_keys.push_back(*minimizer_ptr);
           }
         }
-        taxa.push_back(taxon);
+        else {
+          tok_stream.push_back({TOK_REPEAT, 0});
+        }
       }
       if (opts.use_translated_search && frame_idx != 5)
-        taxa.push_back(READING_FRAME_BORDER_TAXON);
+        tok_stream.push_back({TOK_BORDER_FRAME, 0});
     }
     if (opts.paired_end_processing && mate_num == 0)
-      taxa.push_back(MATE_PAIR_BORDER_TAXON);
+      tok_stream.push_back({TOK_BORDER_MATE, 0});
+  }
+
+  // Phase 2: resolve all distinct minimizers in one prefetched batched pass.
+  static thread_local std::vector<hvalue_t> lookup_vals;
+  lookup_vals.resize(lookup_keys.size());
+  if (! lookup_keys.empty())
+    hash->GetBatch(lookup_keys.data(), lookup_vals.data(), lookup_keys.size());
+
+  // Phase 3: replay token stream, reproducing the original behavior exactly.
+  {
+    taxid_t last_taxon = 0;
+    for (size_t ti = 0; ti < tok_stream.size(); ti++) {
+      const MinToken &tok = tok_stream[ti];
+      taxid_t taxon = 0;
+      switch (tok.kind) {
+        case TOK_AMBIG:
+          taxa.push_back(AMBIGUOUS_SPAN_TAXON);
+          continue;
+        case TOK_BORDER_FRAME:
+          taxa.push_back(READING_FRAME_BORDER_TAXON);
+          continue;
+        case TOK_BORDER_MATE:
+          taxa.push_back(MATE_PAIR_BORDER_TAXON);
+          continue;
+        case TOK_SKIP:
+          taxon = 0;
+          last_taxon = 0;
+          break;
+        case TOK_LOOKUP:
+          taxon = lookup_vals[tok.key_idx];
+          last_taxon = taxon;
+          if (taxon) {
+            minimizer_hit_groups++;
+            if (!opts.report_filename.empty())
+              curr_taxon_counts[taxon].add_kmer(lookup_keys[tok.key_idx]);
+          }
+          break;
+        default:  // TOK_REPEAT
+          taxon = last_taxon;
+          break;
+      }
+      if (taxon) {
+        if (opts.quick_mode && minimizer_hit_groups >= opts.minimum_hit_groups) {
+          call = taxon;
+          goto finished_searching;
+        }
+        hit_counts[taxon]++;
+      }
+      taxa.push_back(taxon);
+    }
   }
 
   finished_searching:

--- a/src/compact_hash.h
+++ b/src/compact_hash.h
@@ -11,6 +11,8 @@
 #include "mmap_file.h"
 #include "kraken2_headers.h"
 #include "kraken2_data.h"
+#include <sys/mman.h>
+#include <cstdlib>
 
 namespace kraken2 {
 
@@ -168,16 +170,20 @@ CompactHashTable<Cell>::CompactHashTable(size_t capacity, size_t key_bits, size_
     errx(EX_SOFTWARE, "value bits cannot be zero");
   for (size_t i = 0; i < LOCK_ZONES; i++)
     omp_init_lock(&zone_locks_[i]);
-  try {
-    table_ = new Cell[capacity_];
-  } catch (std::bad_alloc &ex) {
-    std::cerr << "Failed attempt to allocate " << (sizeof(*table_) * capacity_) << "bytes;\n"
-              << "you may not have enough free memory to build this database.\n"
-              << "Perhaps increasing the k-mer length, or reducing memory usage from\n"
-              << "other programs could help you build this database?" << std::endl;
-    errx(EX_OSERR, "unable to allocate hash table memory");
+  {
+    size_t table_bytes = capacity_ * sizeof(*table_);
+    if (posix_memalign((void **) &table_, (size_t) 1 << 21, table_bytes) != 0) {
+      std::cerr << "Failed attempt to allocate " << table_bytes << "bytes;\n"
+                << "you may not have enough free memory to build this database.\n"
+                << "Perhaps increasing the k-mer length, or reducing memory usage from\n"
+                << "other programs could help you build this database?" << std::endl;
+      errx(EX_OSERR, "unable to allocate hash table memory");
+    }
+#ifdef MADV_HUGEPAGE
+    madvise(table_, table_bytes, MADV_HUGEPAGE);
+#endif
+    memset(table_, 0, table_bytes);
   }
-  memset(table_, 0, capacity_ * sizeof(*table_));
 }
 
 template<typename Cell>
@@ -193,7 +199,7 @@ CompactHashTable<Cell>::CompactHashTable(const char *filename, bool memory_mappi
 template<typename Cell>
 CompactHashTable<Cell>::~CompactHashTable() {
   if (! file_backed_)
-    delete[] table_;
+    free(table_);
   if (locks_initialized_)
     for (size_t i = 0; i < LOCK_ZONES; i++)
       omp_destroy_lock(&zone_locks_[i]);
@@ -227,16 +233,24 @@ void CompactHashTable<Cell>::LoadTable(const char *filename, bool memory_mapping
     ifs.read((char *) &size_, sizeof(size_));
     ifs.read((char *) &key_bits_, sizeof(key_bits_));
     ifs.read((char *) &value_bits_, sizeof(value_bits_));
-    try {
-      table_ = new Cell[capacity_];
-    } catch (std::bad_alloc &ex) {
-      std::cerr << "Failed attempt to allocate " << (sizeof(*table_) * capacity_) << "bytes;\n"
-                << "you may not have enough free memory to load this database.\n"
-                << "If your computer has enough RAM, perhaps reducing memory usage from\n"
-                << "other programs could help you load this database?" << std::endl;
-      errx(EX_OSERR, "unable to allocate hash table memory");
+    {
+      size_t table_bytes = capacity_ * sizeof(*table_);
+      // 2MB-aligned so MADV_HUGEPAGE (where supported) can back the multi-GB
+      // table with huge pages, cutting TLB-miss page-walks on the random-access
+      // lookup path (large win on aarch64/Graviton). Cell is POD; free() pairs
+      // with this. On platforms without THP the madvise is simply compiled out.
+      if (posix_memalign((void **) &table_, (size_t) 1 << 21, table_bytes) != 0) {
+        std::cerr << "Failed attempt to allocate " << table_bytes << "bytes;\n"
+                  << "you may not have enough free memory to load this database.\n"
+                  << "If your computer has enough RAM, perhaps reducing memory usage from\n"
+                  << "other programs could help you load this database?" << std::endl;
+        errx(EX_OSERR, "unable to allocate hash table memory");
+      }
+#ifdef MADV_HUGEPAGE
+      madvise(table_, table_bytes, MADV_HUGEPAGE);
+#endif
+      ifs.read((char *) table_, table_bytes);
     }
-    ifs.read((char *) table_, capacity_ * sizeof(*table_));
     if (! ifs)
       errx(EX_OSERR, "Error reading in hash table");
     file_backed_ = false;

--- a/src/compact_hash.h
+++ b/src/compact_hash.h
@@ -118,6 +118,7 @@ template<typename Cell> class CompactHashTable : public KeyValueStore {
   ~CompactHashTable();
 
   hvalue_t Get(hkey_t key) const;
+  void GetBatch(const hkey_t *keys, hvalue_t *out, size_t n) const;
   bool FindIndex(hkey_t key, size_t *idx) const;
 
   // How CompareAndSet works:
@@ -370,6 +371,24 @@ hvalue_t CompactHashTable<Cell>::Get(hkey_t key) const {
       break;  // search over, we've exhausted the table
   }
   return 0;
+}
+
+// Resolve a batch of keys, software-prefetching the initial probe cell of a key
+// PREFETCH_DIST iterations ahead so multiple cache-missing loads are in flight at
+// once (memory-level parallelism). One virtual dispatch per batch amortizes away.
+template<typename Cell>
+void CompactHashTable<Cell>::GetBatch(const hkey_t *keys, hvalue_t *out, size_t n) const {
+  static const size_t PREFETCH_DIST = [] {
+    const char *e = getenv("K2_PREFETCH_DIST");
+    return e ? (size_t) atoi(e) : (size_t) 8;
+  }();
+  for (size_t i = 0; i < n; i++) {
+    if (i + PREFETCH_DIST < n) {
+      uint64_t hc = MurmurHash3(keys[i + PREFETCH_DIST]);
+      __builtin_prefetch(&table_[hc % capacity_], 0, 1);
+    }
+    out[i] = Get(keys[i]);
+  }
 }
 
 template<typename Cell>

--- a/src/compact_hash.h
+++ b/src/compact_hash.h
@@ -13,6 +13,9 @@
 #include "kraken2_data.h"
 #include <sys/mman.h>
 #include <cstdlib>
+#include <fcntl.h>
+#include <unistd.h>
+#include <cerrno>
 
 namespace kraken2 {
 
@@ -205,6 +208,72 @@ CompactHashTable<Cell>::~CompactHashTable() {
       omp_destroy_lock(&zone_locks_[i]);
 }
 
+// Read exactly n bytes from fd into buf, looping over short reads (a single
+// read() is capped well below multi-GB sizes), retrying on EINTR. errx on
+// error or premature EOF.
+static inline void read_fully(int fd, void *buf, size_t n, const char *what) {
+  char *p = (char *) buf;
+  while (n > 0) {
+    ssize_t r = read(fd, p, n);
+    if (r < 0) {
+      if (errno == EINTR) continue;
+      errx(EX_OSERR, "error reading %s", what);
+    }
+    if (r == 0)
+      errx(EX_DATAERR, "unexpected end of file reading %s", what);
+    p += r;
+    n -= (size_t) r;
+  }
+}
+
+// Number of concurrent reader threads for loading the table; tunable via
+// K2_DB_READ_THREADS (default 8). More streams raise I/O queue depth, which is
+// what saturates the device — reading is I/O-bound, not CPU-bound, so this can
+// exceed core count.
+static inline int db_read_threads() {
+  const char *e = getenv("K2_DB_READ_THREADS");
+  int n = e ? atoi(e) : 8;
+  return n > 0 ? n : 1;
+}
+
+// Fill [buf, buf+n) from fd starting at file offset base_off using `threads`
+// concurrent pread() streams over disjoint chunks. Each pread carries its own
+// offset and is thread-safe. errx on error/EOF.
+static inline void pread_parallel(int fd, void *buf, size_t n, off_t base_off,
+                                  int threads, const char *what) {
+  if (threads < 1) threads = 1;
+  size_t chunk = (n + (size_t) threads - 1) / (size_t) threads;
+  // Set to 1 by any thread that hits a read error. Plain assignment is safe here:
+  // every writer stores the same value, and the read below runs after the parallel
+  // for's implicit barrier (no concurrent access), so no atomics are needed -- and
+  // it avoids OpenMP 3.1's `atomic write` for broader toolchain compatibility.
+  int failed = 0;
+  #pragma omp parallel for schedule(static) num_threads(threads)
+  for (int t = 0; t < threads; t++) {
+    size_t start = (size_t) t * chunk;
+    if (start >= n) continue;
+    size_t len = chunk < n - start ? chunk : n - start;
+    char *p = (char *) buf + start;
+    off_t off = base_off + (off_t) start;
+    size_t got = 0;
+    while (got < len) {
+      ssize_t r = pread(fd, p + got, len - got, off + (off_t) got);
+      if (r < 0) {
+        if (errno == EINTR) continue;
+        failed = 1;
+        break;
+      }
+      if (r == 0) {  // premature EOF
+        failed = 1;
+        break;
+      }
+      got += (size_t) r;
+    }
+  }
+  if (failed)
+    errx(EX_OSERR, "error reading %s", what);
+}
+
 template<typename Cell>
 void CompactHashTable<Cell>::LoadTable(const char *filename, bool memory_mapping) {
   locks_initialized_ = false;
@@ -228,11 +297,16 @@ void CompactHashTable<Cell>::LoadTable(const char *filename, bool memory_mapping
     file_backed_ = true;
   }
   else {
-    std::ifstream ifs(filename);
-    ifs.read((char *) &capacity_, sizeof(capacity_));
-    ifs.read((char *) &size_, sizeof(size_));
-    ifs.read((char *) &key_bits_, sizeof(key_bits_));
-    ifs.read((char *) &value_bits_, sizeof(value_bits_));
+    int fd = open(filename, O_RDONLY);
+    if (fd < 0)
+      errx(EX_OSERR, "unable to open %s", filename);
+    read_fully(fd, &capacity_, sizeof(capacity_), filename);
+    read_fully(fd, &size_, sizeof(size_), filename);
+    read_fully(fd, &key_bits_, sizeof(key_bits_), filename);
+    read_fully(fd, &value_bits_, sizeof(value_bits_), filename);
+    off_t table_off = lseek(fd, 0, SEEK_CUR);  // byte offset where the table begins
+    if (table_off < 0)
+      errx(EX_OSERR, "lseek failed on %s", filename);
     {
       size_t table_bytes = capacity_ * sizeof(*table_);
       // 2MB-aligned so MADV_HUGEPAGE (where supported) can back the multi-GB
@@ -249,10 +323,18 @@ void CompactHashTable<Cell>::LoadTable(const char *filename, bool memory_mapping
 #ifdef MADV_HUGEPAGE
       madvise(table_, table_bytes, MADV_HUGEPAGE);
 #endif
-      ifs.read((char *) table_, table_bytes);
+      // Read the multi-GB table with several concurrent pread() streams. A single
+      // sequential read keeps too few requests in flight (bounded by the small
+      // default readahead window) to saturate a fast block device such as EBS, so
+      // load is throttled well below device throughput. Splitting the table across
+      // N threads, each pread()-ing a disjoint region, raises the effective I/O
+      // queue depth and lets the device run at full speed. pread is thread-safe
+      // (it does not use or move the shared file offset). This is a pure userspace
+      // change: no privileges, no host/readahead tuning, identical in a container.
+      // Without OpenMP the pragma is ignored and this degrades to a serial read.
+      pread_parallel(fd, table_, table_bytes, table_off, db_read_threads(), filename);
     }
-    if (! ifs)
-      errx(EX_OSERR, "Error reading in hash table");
+    close(fd);
     file_backed_ = false;
   }
 }

--- a/src/kseq.h
+++ b/src/kseq.h
@@ -25,16 +25,17 @@
 
 /* Last Modified: 05MAR2012 */
 
+/* Vendored from klib (https://github.com/attractivechaos/klib), current upstream.
+   ONLY local change vs upstream: in ks_getuntil2, the two memchr() results are
+   cast to (unsigned char*) so this header compiles when included in C++ TUs (in
+   C the void* conversion is implicit). Re-apply if updating from upstream. */
+
 #ifndef AC_KSEQ_H
 #define AC_KSEQ_H
 
 #include <ctype.h>
 #include <string.h>
 #include <stdlib.h>
-
-#ifdef USE_MALLOC_WRAPPERS
-#  include "malloc_wrap.h"
-#endif
 
 #define KS_SEP_SPACE 0 // isspace(): \t, \n, \v, \f, \r
 #define KS_SEP_TAB   1 // isspace() && !' '
@@ -48,6 +49,7 @@
 		type_t f;								\
 	} kstream_t;
 
+#define ks_err(ks) ((ks)->end == -1)
 #define ks_eof(ks) ((ks)->is_eof && (ks)->begin >= (ks)->end)
 #define ks_rewind(ks) ((ks)->is_eof = (ks)->begin = (ks)->end = 0)
 
@@ -70,11 +72,13 @@
 #define __KS_GETC(__read, __bufsize)						\
 	static inline int ks_getc(kstream_t *ks)				\
 	{														\
+		if (ks_err(ks)) return -3;							\
 		if (ks->is_eof && ks->begin >= ks->end) return -1;	\
 		if (ks->begin >= ks->end) {							\
 			ks->begin = 0;									\
 			ks->end = __read(ks->f, ks->buf, __bufsize);	\
 			if (ks->end == 0) { ks->is_eof = 1; return -1;}	\
+			if (ks->end == -1) { ks->is_eof = 1; return -3;}\
 		}													\
 		return (int)ks->buf[ks->begin++];					\
 	}
@@ -99,19 +103,21 @@ typedef struct __kstring_t {
 		str->l = append? str->l : 0;									\
 		for (;;) {														\
 			int i;														\
+			if (ks_err(ks)) return -3;									\
 			if (ks->begin >= ks->end) {									\
 				if (!ks->is_eof) {										\
 					ks->begin = 0;										\
 					ks->end = __read(ks->f, ks->buf, __bufsize);		\
 					if (ks->end == 0) { ks->is_eof = 1; break; }		\
+					if (ks->end == -1) { ks->is_eof = 1; return -3; }	\
 				} else break;											\
 			}															\
-			if (delimiter == KS_SEP_LINE) { \
-				for (i = ks->begin; i < ks->end; ++i) \
-					if (ks->buf[i] == '\n') break; \
+			if (delimiter == KS_SEP_LINE) {								\
+				unsigned char *sep = (unsigned char*)memchr(ks->buf + ks->begin, '\n', ks->end - ks->begin); \
+				i = sep != NULL ? sep - ks->buf : ks->end;				\
 			} else if (delimiter > KS_SEP_MAX) {						\
-				for (i = ks->begin; i < ks->end; ++i)					\
-					if (ks->buf[i] == delimiter) break;					\
+				unsigned char *sep = (unsigned char*)memchr(ks->buf + ks->begin, delimiter, ks->end - ks->begin); \
+				i = sep != NULL ? sep - ks->buf : ks->end;				\
 			} else if (delimiter == KS_SEP_SPACE) {						\
 				for (i = ks->begin; i < ks->end; ++i)					\
 					if (isspace(ks->buf[i])) break;						\
@@ -171,25 +177,26 @@ typedef struct __kstring_t {
    >=0  length of the sequence (normal)
    -1   end-of-file
    -2   truncated quality string
+   -3   error reading stream
  */
 #define __KSEQ_READ(SCOPE) \
 	SCOPE int kseq_read(kseq_t *seq) \
 	{ \
-		int c; \
+		int c,r; \
 		kstream_t *ks = seq->f; \
 		if (seq->last_char == 0) { /* then jump to the next header line */ \
-			while ((c = ks_getc(ks)) != -1 && c != '>' && c != '@'); \
-			if (c == -1) return -1; /* end of file */ \
+			while ((c = ks_getc(ks)) >= 0 && c != '>' && c != '@'); \
+			if (c < 0) return c; /* end of file or error*/ \
 			seq->last_char = c; \
 		} /* else: the first header char has been read in the previous call */ \
 		seq->comment.l = seq->seq.l = seq->qual.l = 0; /* reset all members */ \
-		if (ks_getuntil(ks, 0, &seq->name, &c) < 0) return -1; /* normal exit: EOF */ \
+		if ((r=ks_getuntil(ks, 0, &seq->name, &c)) < 0) return r;  /* normal exit: EOF or error */ \
 		if (c != '\n') ks_getuntil(ks, KS_SEP_LINE, &seq->comment, 0); /* read FASTA/Q comment */ \
 		if (seq->seq.s == 0) { /* we can do this in the loop below, but that is slower */ \
 			seq->seq.m = 256; \
 			seq->seq.s = (char*)malloc(seq->seq.m); \
 		} \
-		while ((c = ks_getc(ks)) != -1 && c != '>' && c != '+' && c != '@') { \
+		while ((c = ks_getc(ks)) >= 0 && c != '>' && c != '+' && c != '@') { \
 			if (c == '\n') continue; /* skip empty lines */ \
 			seq->seq.s[seq->seq.l++] = c; /* this is safe: we always have enough space for 1 char */ \
 			ks_getuntil2(ks, KS_SEP_LINE, &seq->seq, 0, 1); /* read the rest of the line */ \
@@ -206,9 +213,10 @@ typedef struct __kstring_t {
 			seq->qual.m = seq->seq.m; \
 			seq->qual.s = (char*)realloc(seq->qual.s, seq->qual.m); \
 		} \
-		while ((c = ks_getc(ks)) != -1 && c != '\n'); /* skip the rest of '+' line */ \
+		while ((c = ks_getc(ks)) >= 0 && c != '\n'); /* skip the rest of '+' line */ \
 		if (c == -1) return -2; /* error: no quality string */ \
-		while (ks_getuntil2(ks, KS_SEP_LINE, &seq->qual, 0, 1) >= 0 && seq->qual.l < seq->seq.l); \
+		while ((c = ks_getuntil2(ks, KS_SEP_LINE, &seq->qual, 0, 1) >= 0 && seq->qual.l < seq->seq.l)); \
+		if (c == -3) return -3; /* stream error */ \
 		seq->last_char = 0;	/* we have not come to the next header line */ \
 		if (seq->seq.l != seq->qual.l) return -2; /* error: qual string is of a different length */ \
 		return seq->seq.l; \

--- a/src/kv_store.h
+++ b/src/kv_store.h
@@ -26,6 +26,7 @@ enum CellType {
 class KeyValueStore {
   public:
   virtual hvalue_t Get(hkey_t key) const = 0;
+  virtual void GetBatch(const hkey_t *keys, hvalue_t *out, size_t n) const = 0;
   virtual ~KeyValueStore() {}
 
   // static CellType GetKVCellType(std::string &filename);

--- a/src/seqreader.h
+++ b/src/seqreader.h
@@ -11,7 +11,15 @@
 #include "kseq.h"
 #include <fcntl.h>
 
-KSEQ_INIT(int, read)
+// Expand KSEQ_INIT by hand so the kstream uses a 64KB read buffer instead of
+// klib's 16KB default, while keeping kseq.h verbatim-upstream. Input is read
+// through this buffer inside classify's serialized reader critical section; 64KB
+// matches the default Linux pipe capacity feeding us from the igzip decompressor,
+// so a single read() can drain a full pipe rather than taking ~4 syscalls.
+KSTREAM_INIT(int, read, 65536)
+__KSEQ_TYPE(int)
+__KSEQ_BASIC(static, int)
+__KSEQ_READ(static)
 
 namespace kraken2 {
 


### PR DESCRIPTION
## Context

I want to be clear about how I'm using and benchmarking classify's performance, because while I suspect most or all of my changes are generally beneficial, the degree of improvement is almost certainly going to vary by how classify is being used.

My use case is running `classify` using a ~35GB database, on hosts with ~64GB of memory and 8 cpus, with gzipped fastq inputs that represent ~1-8X whole genome sequencing of cats (broadly similar size genome to humans).  I'm running with 8 cpus/threads, writing both the primary output and report to disk.  I've been benchmarking with on AWS, with modern (gen7 and gen8 instances) with EBS volumes whose throughput has been cranked up to 1GB/s.  The outputs are fed into [k2tools](https://github.com/fulcrumgenomics/k2tools) `filter`, to filter out reads coming from non-cat genomes.

The first bottleneck I ran into is that both the old `kraken2` wrapper nor the newer `k2` wrapper appear to be the bottleneck when working directly with gzipped fastqs.  As such, my invocations now use `igzip` from [Intel's isa-l package](https://github.com/intel/isa-l) something like:

```bash
mkfifo r1.fastq
mkfifo r2.fastq

igzip -dc r1.fastq.gz > r1.fastq
igzip -dc r2.fastq.gz > r2.fastq

kraken2 \
    --db . \
    --threads 8 \
    --paired \
    --output kraken-out.txt \
    --report kraken-report.txt \
    --report-zero-counts \
    r1.fastq \
    r2.fastq
```

Under this regime, the changes described below yield:
- About a 3-fold reduction in the database load time
- A 1.3-1.7x improvement in classification throughput (arch dependent) after database load

## Summary

This PR speeds up `classify` substantially while producing **byte-identical output**. The work targets the fact that classification is dominated by memory-latency-bound random lookups into the compact hash table, which is especially punishing on aarch64 (e.g. AWS Graviton), and that database load is single-threaded.

The four changes are independent and reviewable commit by commit. If you'd prefer them as separate PRs, I'm happy to split them up.

## What changed (one commit each, in order)

1. **Back the compact hash table with huge pages where available.** The multi-GB table is accessed in an effectively random pattern, so with 4KB pages the TLB cannot cover the working set and each probe risks a page-table walk; this dominates the lookup path and is worst on aarch64. The table is now allocated 2MB-aligned via `posix_memalign` and advised with `madvise(MADV_HUGEPAGE)`, so a handful of huge pages cover what previously needed thousands of 4KB entries. The `madvise` is guarded by `#ifdef MADV_HUGEPAGE` so the code still builds and runs where transparent huge pages are unavailable (e.g. macOS).

2. **Load the hash table with parallel reads.** Loading the database read the entire multi-GB table as a single sequential stream, which keeps too few I/O requests in flight to saturate a fast block device (the load is neither CPU- nor throughput-bound, just starved for I/O parallelism). The table is now read with several concurrent `pread` streams over disjoint regions, raising the effective queue depth. The reader count is tunable via `K2_DB_READ_THREADS` (default 8); without OpenMP the parallel-for is ignored and it degrades cleanly to a serial read.

3. **Update vendored `kseq.h` to current upstream klib, with a 64KB read buffer.** The in-tree `kseq.h` was a 2012-era copy that scans for line terminators one byte at a time; current upstream uses `memchr()`, which the C library vectorizes and which is far faster on the long sequence/quality lines of FASTQ. The only local deviation from upstream is a `(unsigned char*)` cast on the two `memchr()` results so the header compiles when included in C++ (documented in the file). Separately, `KSEQ_INIT` is expanded by hand in `seqreader.h` to use a 64KB stream buffer instead of klib's 16KB default (leaving `kseq.h` itself verbatim upstream).

4. **Batch minimizer lookups with software prefetch.** The per-read loop interleaved minimizer scanning with one hash lookup at a time, so the core stalls on each cache-missing lookup with little memory-level parallelism. `ClassifySequence` is restructured into three phases: scan the read pair's minimizers into a compact token stream (deferring lookups), resolve all distinct minimizers in one batched pass that software-prefetches each key's first probe cell several iterations ahead, then replay the token stream to rebuild the per-read state exactly as before. Phase 3 is a faithful re-expression of the original control flow, so output is unchanged; only the memory access pattern differs. The prefetch distance is tunable via `K2_PREFETCH_DIST` (default 8).

## Performance

5 GB/side paired FASTQ, 8 threads, identical decompressed input, classification rate as reported by kraken2:

| platform | stock | this PR | speedup |
| --- | --- | --- | --- |
| Graviton4 (r8g.2xlarge, clang) | 266 s | 202 s | 1.32x (−24%) |
| x86 (r7i.2xlarge, gcc) | 337 s | 204 s | 1.65x (−39%) |

Cold database load of the ~34 GB hash (Graviton4): roughly **100 s → 34 s (~3x)** from the parallel-read change.

## Correctness

Output is byte-identical to stock. We verified this both by line-by-line analysis of the lookup restructuring and empirically: building stock and patched side by side and diffing outputs across single-end, paired-end, quick mode, confidence thresholds, the `--report` and `--report-minimizer-data` paths, memory-mapped loading, empty input, zero-minimizer reads, and ambiguous/`N` reads — every case matched, and on real 5 GB/side paired data the output and report MD5s were identical on both architectures (clang/aarch64 and gcc/x86). Varying `K2_PREFETCH_DIST` and `K2_DB_READ_THREADS` did not change output.

Since the project has no automated output tests, the simplest way to confirm locally is to run stock vs this branch on the same input and `md5sum` the `--output` and `--report` files.

## Notes

- New environment knobs default to sensible values and need not be set: `K2_PREFETCH_DIST` (default 8) and `K2_DB_READ_THREADS` (default 8).
- Builds cleanly with clang and gcc, on aarch64 and x86, and with OpenMP disabled; `MADV_HUGEPAGE` and the parallel read both degrade gracefully where unavailable.
- A separate, standalone PR fixes a pre-existing double-free in the `classify` exit/daemon-teardown paths; it is intentionally not included here.
