### PR TITLE
Fix two out-of-bounds reads found by AddressSanitizer

### DIFF
--- a/src/reports.cc
+++ b/src/reports.cc
@@ -160,7 +160,7 @@ void KrakenReportDFS(uint32_t taxid, ofstream &ofs, bool report_zeros,
   else if (rank == "species") { rank_code = 'S'; rank_depth = 0; }
   else { rank_depth++; }
 
-  string rank_str(&rank_code, 0, 1);
+  string rank_str(1, rank_code);
   if (rank_depth != 0)
     rank_str += std::to_string(rank_depth);
 

--- a/src/seqreader.cc
+++ b/src/seqreader.cc
@@ -11,7 +11,9 @@ using std::string;
 namespace kraken2 {
 
 void StripString(string &str) {
-  while (isspace(str.back()))
+  // back() on an empty string is undefined, and an empty input line reaches
+  // here.  isspace also requires a value representable as unsigned char.
+  while (! str.empty() && isspace((unsigned char) str.back()))
     str.pop_back();
 }
 


### PR DESCRIPTION
Two reads past the end of a buffer, found while profiling `classify` under `clang -fsanitize=address,undefined`. Neither changes output on well-formed input, but both are undefined behavior and either can fault depending on stack and heap layout. I hit the first one as a `SIGBUS` in `--report` generation.

### `reports.cc`: `KrakenReportDFS`

```cpp
string rank_str(&rank_code, 0, 1);
```

`rank_code` is a single `char` parameter, so no `basic_string` constructor taking `(const char*, size_type, size_type)` applies. Overload resolution instead selects `(const basic_string&, size_type, size_type)` by implicitly converting `&rank_code` to a `std::string`, which requires reading from that address **as a NUL-terminated C string**. The scan runs past the single character until it happens to meet a zero byte.

```
ERROR: AddressSanitizer: stack-buffer-overflow
    #0 kraken2::KrakenReportDFS(...) reports.cc:163
```

Replaced with the `(size_type, charT)` constructor, which produces the same one-character string and is presumably what was intended.

### `seqreader.cc`: `StripString`

```cpp
while (isspace(str.back()))
  str.pop_back();
```

`back()` on an empty string is undefined, and an empty input line reaches this function. The character is also passed to `isspace` without converting to `unsigned char`, which is undefined for negative values where `char` is signed.

```
ERROR: AddressSanitizer: heap-buffer-overflow
    #0 kraken2::StripString(std::string&) seqreader.cc:14
    #1 kraken2::BatchSequenceReader::ReadNextSequence(...) seqreader.cc:143
```

### Verification

Against a 16 GB `pluspf_16_GB` index with 100k simulated read pairs, `clang -fsanitize=address,undefined`:

- Both reports are gone, and no others appear across paired, unpaired, single-file-pairs (`-S`) and FASTA input.
- Per-read output and the `--report` file are byte-for-byte identical to the unmodified code in all four modes.